### PR TITLE
Merge Tx search levels (#54)

### DIFF
--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -630,12 +630,23 @@ static void Av1EncodeLoop(
             residual16bit->strideY,
             context_ptr->blk_geom->tx_width[context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->txb_itr]);
+#if TX_SEARCH_LEVELS
+        uint8_t  tx_search_skip_fag = picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC ? get_skip_tx_search_flag(
+            context_ptr->blk_geom->sq_size,
+            MAX_MODE_COST,
+            0,
+            1) : 1;
+
+        if (!tx_search_skip_fag) {
+#else
 
 #if ENCDEC_TX_SEARCH
 #if ENCODER_MODE_CLEANUP
         if (picture_control_set_ptr->enc_mode > ENC_M1) {
 #endif
             if (context_ptr->blk_geom->sq_size < 128) //no tx search for 128x128 for now
+#endif
+#endif
                 encode_pass_tx_search(
                     picture_control_set_ptr,
                     context_ptr,
@@ -657,7 +668,7 @@ static void Av1EncodeLoop(
 #if ENCODER_MODE_CLEANUP
         }
 #endif
-#endif
+
         Av1EstimateTransform(
             ((int16_t*)residual16bit->bufferY) + scratchLumaOffset,
             residual16bit->strideY,
@@ -1033,11 +1044,22 @@ static void Av1EncodeLoop16bit(
                 context_ptr->blk_geom->tx_width[context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->txb_itr]);
 
+#if TX_SEARCH_LEVELS
+            uint8_t  tx_search_skip_fag = picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC ? get_skip_tx_search_flag(
+                context_ptr->blk_geom->sq_size,
+                MAX_MODE_COST,
+                0,
+                1) : 1;
+
+            if (!tx_search_skip_fag) {
+#else
 #if ENCDEC_TX_SEARCH
 #if ENCODER_MODE_CLEANUP
             if (picture_control_set_ptr->enc_mode > ENC_M1) {
 #endif
                 if (context_ptr->blk_geom->sq_size < 128) //no tx search for 128x128 for now
+#endif
+#endif
                     encode_pass_tx_search_hbd(
                         picture_control_set_ptr,
                         context_ptr,
@@ -1058,7 +1080,7 @@ static void Av1EncodeLoop16bit(
 #if ENCODER_MODE_CLEANUP
             }
 #endif
-#endif
+
 
             Av1EstimateTransform(
                 ((int16_t*)residual16bit->bufferY) + scratchLumaOffset,

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -35,7 +35,7 @@
 extern "C" {
 #endif
 
-    //Mode definition : Only one mode should be ON at a time
+     //Mode definition : Only one mode should be ON at a time
 #define MR_MODE                                         0
 #define SHUT_FILTERING                                  0 // CDEF RESTORATION DLF
     ////
@@ -140,6 +140,7 @@ extern "C" {
 #define FAST_CDEF                                       1
 #define FAST_SG                                         1
 #define FAST_WN                                         1
+#define TX_SEARCH_LEVELS                                1 
 
 /********************************************************/
 /****************** Pre-defined Values ******************/
@@ -475,6 +476,14 @@ typedef struct InterpFilterParams {
     InterpFilter interp_filter;
 } InterpFilterParams;
 
+#if TX_SEARCH_LEVELS
+typedef enum TX_SEARCH_LEVEL {
+    TX_SEARCH_OFF,
+    TX_SEARCH_ENC_DEC,
+    TX_SEARCH_INTER_DEPTH,
+    TX_SEARCH_FULL_LOOP
+} TX_SEARCH_LEVEL;
+#endif
 
 
 

--- a/Source/Lib/Codec/EbFullLoop.c
+++ b/Source/Lib/Codec/EbFullLoop.c
@@ -1191,11 +1191,16 @@ void ProductFullLoopTxSearch(
     for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
         tx_type = (TxType)tx_type_index;
         if (!allowed_tx_mask[tx_type]) continue;
+#if TX_SEARCH_LEVELS
+        if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set)
+            if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#else
 #if FAST_TX_SEARCH
 #if ENCODER_MODE_CLEANUP
         if (picture_control_set_ptr->enc_mode == ENC_M1)
 #endif
          if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#endif
 #endif
         context_ptr->three_quad_energy = 0;
         uint32_t txb_itr = 0;
@@ -1402,11 +1407,16 @@ void encode_pass_tx_search(
     for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
         tx_type = (TxType)tx_type_index;
 
+#if TX_SEARCH_LEVELS
+        if(picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set)
+            if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#else
 #if FAST_TX_SEARCH
 #if ENCODER_MODE_CLEANUP
         if (picture_control_set_ptr->enc_mode == ENC_M1)
 #endif
             if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#endif
 #endif
         const int32_t eset = get_ext_tx_set(txSize, is_inter, picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used);
         // eset == 0 should correspond to a set with only DCT_DCT and there
@@ -1602,11 +1612,16 @@ void encode_pass_tx_search_hbd(
     for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
         tx_type = (TxType)tx_type_index;
         ////if (!allowed_tx_mask[tx_type]) continue;
+#if TX_SEARCH_LEVELS
+        if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set)
+            if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#else
 #if FAST_TX_SEARCH
 #if ENCODER_MODE_CLEANUP
         if (picture_control_set_ptr->enc_mode == ENC_M1 )
 #endif
             if (!allowed_tx_set_a[txSize][tx_type]) continue;
+#endif
 #endif
         const int32_t eset = get_ext_tx_set(txSize, is_inter, picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used);
         // eset == 0 should correspond to a set with only DCT_DCT and there

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -397,7 +397,10 @@ EbErrorType PreModeDecision(
     uint32_t                         *full_candidate_total_count_ptr,
     uint8_t                          *best_candidate_index_array,
     uint8_t                          *disable_merge_index,
-    EbBool                         same_fast_full_candidate
+#if TX_SEARCH_LEVELS
+    uint64_t                         *ref_fast_cost,
+#endif
+    EbBool                           same_fast_full_candidate
 )
 {
     UNUSED(cu_ptr);
@@ -456,7 +459,13 @@ EbErrorType PreModeDecision(
             }
         }
     }
-
+#if TX_SEARCH_LEVELS
+    for (i = 0; i < fullReconCandidateCount; i++) {
+        if (*(buffer_ptr_array[i]->fast_cost_ptr) < *ref_fast_cost) {
+            *ref_fast_cost = *(buffer_ptr_array[i]->fast_cost_ptr);
+        }
+    }
+#endif
     // Set (*full_candidate_total_count_ptr) to fullReconCandidateCount
     (*full_candidate_total_count_ptr) = fullReconCandidateCount;
 

--- a/Source/Lib/Codec/EbModeDecision.h
+++ b/Source/Lib/Codec/EbModeDecision.h
@@ -275,6 +275,9 @@ extern "C" {
         uint32_t                       *full_candidate_total_count_ptr,
         uint8_t                        *best_candidate_index_array,
         uint8_t                        *disable_merge_index,
+#if TX_SEARCH_LEVELS
+        uint64_t                       *ref_fast_cost,
+#endif
         EbBool                          same_fast_full_candidate);
 
     typedef EbErrorType(*EB_INTRA_4x4_FAST_LUMA_COST_FUNC)(

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -14282,6 +14282,11 @@ extern "C" {
         int32_t                               cdf_ref_frame_strenght;
         int32_t                               use_ref_frame_cdef_strength;
 #endif
+#if TX_SEARCH_LEVELS
+        uint8_t                               tx_search_level;
+        uint64_t                              tx_weight;
+        uint8_t                               tx_search_reduced_set;
+#endif
 
     } PictureParentControlSet_t;
 

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -733,6 +733,31 @@ EbErrorType signal_derivation_multi_processes_oq(
         cm->wn_filter_mode = 2;
 #endif
 
+#if TX_SEARCH_LEVELS
+    // Tx_search Level                                Settings
+    // 0                                              OFF
+    // 1                                              Tx search at encdec
+    // 2                                              Tx search at inter-depth
+    // 3                                              Tx search at full loop
+
+    if (picture_control_set_ptr->enc_mode > ENC_M1) {
+        picture_control_set_ptr->tx_search_level = TX_SEARCH_ENC_DEC;
+    }
+    else {
+        picture_control_set_ptr->tx_search_level = TX_SEARCH_FULL_LOOP;
+    }
+
+    // Set tx search skip weights (MAX_MODE_COST: no skipping; 0: always skipping)
+    picture_control_set_ptr->tx_weight = MAX_MODE_COST;
+
+    // Set tx search reduced set falg (0: full tx set; 1: reduced tx set)
+    if (picture_control_set_ptr->enc_mode == ENC_M1) {
+        picture_control_set_ptr->tx_search_reduced_set = 1;
+    }
+    else {
+        picture_control_set_ptr->tx_search_reduced_set = 0;
+    }
+#endif
     // Intra prediction Level                       Settings
     // 0                                            OFF : disable_angle_prediction
     // 1                                            OFF per block : disable_angle_prediction for 64/32/4
@@ -1096,7 +1121,7 @@ void  Av1GenerateRpsInfo(
         if (pictureIndex == 3) {
             av1Rps->refDpbIndex[0] = base0_idx;
             av1Rps->refDpbIndex[6] = layer1_idx;
-        }
+    }
         else if (pictureIndex == 11) {
             av1Rps->refDpbIndex[0] = layer1_idx;
             av1Rps->refDpbIndex[6] = base1_idx;
@@ -1195,8 +1220,8 @@ void  Av1GenerateRpsInfo(
                 picture_control_set_ptr->showFrame = EB_TRUE;
                 picture_control_set_ptr->hasShowExisting = EB_FALSE;
             }
-            else
-            {
+    else
+    {
                 picture_control_set_ptr->showFrame = EB_FALSE;
                 picture_control_set_ptr->hasShowExisting = EB_FALSE;
             }


### PR DESCRIPTION
* **Added tx search levels***

    enc_mode > ENC_M1
    tx_search_level = TX_SEARCH_ENC_DEC;
    Otherwise
    tx_search_level = TX_SEARCH_FULL_LOOP;

    // Tx_search Level                                Settings
    // 0                                              OFF
    // 1                                              Tx search at encdec
    // 2                                              Tx search at inter-depth
    // 3                                              Tx search at full loop

    // Set tx search skip weights (MAX_MODE_COST: no skipping; 0: always skipping)
    tx_weight = MAX_MODE_COST;

    // Set tx search reduced set falg (0: full tx set; 1: reduced tx set)
    enc_mode == ENC_M1
    tx_search_reduced_set = 1;
    Otherwise
    tx_search_reduced_set = 0;